### PR TITLE
removing copyLib function

### DIFF
--- a/premake/bnet.lua
+++ b/premake/bnet.lua
@@ -37,5 +37,3 @@ project "bnet"
 		BNET_DIR .. "src/**.cpp",
 		BNET_DIR .. "src/**.h",
 	}
-
-	copyLib()

--- a/premake/premake4.lua
+++ b/premake/premake4.lua
@@ -168,9 +168,6 @@ configuration { "Xbox360" }
 
 configuration {} -- reset configuration
 
-function copyLib()
-end
-
 dofile "bnet.lua"
 dofile "chat.lua"
 dofile "http.lua"


### PR DESCRIPTION
3rdparty solutions can easily add a copyLib() call after the dofile "bnet.lua" call
