### PR TITLE
Fixed memory leak when sending message to a failed connection.

### DIFF
--- a/src/bnet.cpp
+++ b/src/bnet.cpp
@@ -234,6 +234,10 @@ namespace bnet
 				m_outgoing.push(_msg);
 				update();
 			}
+			else
+			{
+				msgRelease(_msg);
+			}
 		}
 
 		void update()


### PR DESCRIPTION
Don't know if this is the best way to handle this or if it should be handled at all, so feel free to ignore :)

Some clients might keep the Message pointer and/or use it after bnet::send().